### PR TITLE
Support request optimisation options - agent, x-stream, one-time auth encoding

### DIFF
--- a/seraph-core.js
+++ b/seraph-core.js
@@ -73,7 +73,7 @@ function SeraphCore(options) {
         if (err) throw err;
       }
     }
-    var authString = new Buffer(options.user + ':' + options.pass).toString('base64');
+    var authString = options.authString || (options.authString = new Buffer(options.user + ':' + options.pass).toString('base64'));
     var endpoint = operation.endpoint || options.endpoint;
     var requestOpts = {
       uri: options.server + endpoint + '/' + operation.to,
@@ -83,7 +83,10 @@ function SeraphCore(options) {
         Authorization: 'Basic ' + authString
       }
     };
-    
+
+    if (options.xstream) requestOpts.headers['X-Stream'] = true;
+
+    if (options.agent) requestOpts.agent = options.agent;
 
     if (operation.body) requestOpts.json = operation.body;
 


### PR DESCRIPTION
1) Support request's agent option
2) Support X-Stream option
3) Store Base64 encoding of user and password - rather than encode on every call.
