### PR TITLE
Adding support for SSL/TLS (client certificates)

### DIFF
--- a/seraph-core.js
+++ b/seraph-core.js
@@ -88,6 +88,14 @@ function SeraphCore(options) {
 
     if (options.agent) requestOpts.agent = options.agent;
 
+    if (options.ssl)
+    {
+      requestOpts.cert = options.ssl.cert;
+      requestOpts.key = options.ssl.key;
+      requestOpts.passphrase = options.ssl.passphrase;
+      requestOpts.ca = options.ssl.ca;
+    }
+
     if (operation.body) requestOpts.json = operation.body;
 
     callback = callback.bind(this);


### PR DESCRIPTION
This is needed in specific scenarios. For example, when using nginx as a reverse proxy.
